### PR TITLE
Add new jobs and features

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,32 +1,29 @@
-name: PR Checks 
+name: PR Checks
 
 on:
   pull_request
-  
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.0', '2.7']
     steps:
-      - name: Checks out repo
+      - name: Checkout repo
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v1
         with:
-          path: vendor/bundle
-          key: bundle-use-ruby-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            bundle-use-ruby-${{ hashFiles('.ruby-version') }}-
-      - name: Install dependencies
-        run: |
-          sudo apt-get -yqq install libpq-dev
-          gem install bundler -v '2.1.2'
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Start backing services
+        run: docker-compose up -d
       - name: Run rubocop
         run: bundle exec rubocop
+      - name: Wait for services to come up
+        run: sleep 3
       - name: Run specs
         run: bundle exec rspec spec/
-        

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,7 @@ Metrics/CyclomaticComplexity:
 Layout/LineLength:
   Max: 120
   # Allow comments to be long
-  IgnoredPatterns: ['\A#']
+  AllowedPatterns: ['\A#']
 Metrics/MethodLength:
   Enabled: false
 Metrics/ModuleLength:
@@ -84,7 +84,7 @@ Style/Documentation:
 Style/FormatString:
   EnforcedStyle: percent
 Style/NumericPredicate:
-  IgnoredMethods: ['where']
+  AllowedMethods: ['where']
 Style/RedundantReturn:
   Enabled: false
 Style/RedundantSelf:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ fix:
 	bundle exec rubocop --auto-correct-all
 fmt: fix
 
+up:
+	docker compose up -d
 test:
 	RACK_ENV=test bundle exec rspec spec/
 testf:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ install:
 cop:
 	bundle exec rubocop
 fix:
-	bundle exec rubocop --auto-correct-all
+	bundle exec rubocop --autocorrect-all
 fmt: fix
 
 up:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.4"
+
+services:
+  redis:
+    image: "redis:6"
+    ports:
+      - "22379:6379"

--- a/lib/amigo/queue_backoff_job.rb
+++ b/lib/amigo/queue_backoff_job.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "sidekiq"
+require "sidekiq/api"
+
+# Queue backoff jobs are used for jobs that should not saturate workers,
+# such that jobs on dependent queues end up not running for a while.
+#
+# For example, imagine a queue dedicated to long-running jobs ('slow'),
+# a queue of critical, short-running tasks ('critical'), and 10 worker threads.
+# Imagine 20 'slow' jobs enter that queue, then 2 'critical' jobs.
+#
+# The 10 worker threads start processing the 'slow' queue,
+# and one completes. When that worker thread goes to find its next job,
+# it pulls a job off the 'slow' queue (even with Sidekiq queue priorities,
+# lopsided queue sizes mean it's likely we'll ge ta 'slow' job).
+#
+# When this job starts, it checks the 'critical' queue,
+# which is specified as a *dependent* queue of this job.
+# If it sees the 'critical' queue has latency,
+# the job reschedules itself in the future and then processes the next job.
+#
+# This keeps happening until the worker thread finds a job from
+# the 'critical' queue and processes it successfully.
+#
+# Implementers can override two methods:
+#
+# - `dependent_queues` should return an array of the names of queues that should be checked,
+#   in order of higher-priority-first. See below for Redis performance notes.
+# - `calculate_backoff` is passed a queue name and its latency,
+#   and should return either:
+#   - the backoff duration in seconds (ie the argument to `perform_in`),
+#   - 0 to perform the job immediately, or
+#   - nil to check the next queue with latency.
+#   - Note that if all calls to `calculate_backoff` return nil, the job is performed immediately.
+#
+# BackoffJob supports multiple dependent queues but it checks them one-at-a-time
+# to avoid any unnecessary calls to Redis.
+#
+# == Redis Impacts
+#
+# Using BackoffJob adds an overhead to each perform of a job-
+# specifically, a call to `Redis.lrange` through the Sidekiq API's Sidekiq:::Queue#latency
+# potentially for each queue in `dependent_queues`.
+# This is a fast call (it just gets the last item), but it's not free,
+# so users should be aware of it.
+#
+module Amigo
+  module QueueBackoffJob
+    def self.included(cls)
+      cls.include InstanceMethods
+      cls.prepend PrependedMethods
+    end
+
+    class << self
+      # Reset class state. Mostly used just for testing.
+      def reset
+        @max_backoff = 10
+        is_testing = defined?(::Sidekiq::Testing) && ::Sidekiq::Testing.enabled?
+        @enabled = !is_testing
+        @cache_queue_names = true
+        @cache_latencies = true
+        @all_queue_names = nil
+        @latency_cache_duration = 5
+        @latency_cache = {}
+      end
+
+      # Maximum time into the future a job will reschedule itself for.
+      # Ie, if latency is 30s, and max_backoff is 10, the job will be scheduled
+      # for 10s into the future if it finds backoff pressure.
+      attr_accessor :max_backoff
+
+      # Return true if backoff checks are enabled.
+      attr_accessor :enabled
+
+      def enabled?
+        return @enabled
+      end
+
+      # Cached value of all Sidekiq queues, since they rarely change.
+      # If your queue names change at runtime, set +cache_queue_names+ to false.
+      def all_queue_names
+        return @all_queue_names if @cache_queue_names && @all_queue_names
+        @all_queue_names = ::Sidekiq::Queue.all.map(&:name)
+        return @all_queue_names
+      end
+
+      # Whether all_queue_names should be cached.
+      attr_reader :cache_queue_names
+
+      def cache_queue_names=(v)
+        @cache_queue_names = v
+        @all_queue_names = nil if v == false
+      end
+
+      # Return how long queue latencies should be cached before they are re-fetched from Redis.
+      # Avoids hitting Redis to check latency too often.
+      # Default to 5 seconds. Set to 0 to avoid caching.
+      attr_accessor :latency_cache_duration
+
+      # Check the latency of the queue with the given now.
+      # If the queue has been checked more recently than latency_cache_duration specified,
+      # return the cached value.
+      def check_latency(qname, now: Time.now)
+        return ::Sidekiq::Queue.new(qname).latency if self.latency_cache_duration.zero?
+        cached = @latency_cache[qname]
+        if cached.nil? || (cached[:at] + self.latency_cache_duration) < now
+          @latency_cache[qname] = {at: now, value: ::Sidekiq::Queue.new(qname).latency}
+        end
+        return @latency_cache[qname][:value]
+      end
+    end
+    self.reset
+
+    module InstanceMethods
+      def dependent_queues
+        qname = self.class.get_sidekiq_options["queue"]
+        return ::Amigo::QueueBackoffJob.all_queue_names.reject { |x| x == qname }
+      end
+
+      def calculate_backoff(_queue_name, latency, _args)
+        return [latency, ::Amigo::QueueBackoffJob.max_backoff].min
+      end
+    end
+
+    module PrependedMethods
+      def perform(*args)
+        return super unless ::Amigo::QueueBackoffJob.enabled?
+        # rubocop:disable Style/GuardClause, Lint/NonLocalExitFromIterator
+        dependent_queues.each do |qname|
+          latency = Amigo::QueueBackoffJob.check_latency(qname)
+          # If latency is <= 0, we can skip this queue.
+          next unless latency.positive?
+          # If backoff is nil, ignore this queue and check the next
+          # If it's > 0, defer until the future
+          # If it's <= 0, run the job and check no more queues
+          backoff = calculate_backoff(qname, latency, args)
+          next if backoff.nil?
+          if backoff.positive?
+            self.class.perform_in(backoff, *args)
+            return
+          else
+            return super
+          end
+        end
+        # rubocop:enable Style/GuardClause, Lint/NonLocalExitFromIterator
+        super
+      end
+    end
+  end
+end

--- a/lib/amigo/rate_limited_error_handler.rb
+++ b/lib/amigo/rate_limited_error_handler.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "digest"
+
+# Wrap another Sidekiq error handler so invoking it is rate limited.
+#
+# Useful when wrapping a usage-based error reporter like Sentry,
+# which can be hammered in the case of an issue like connectivity
+# that causes all jobs and retries to fail.
+# It is suggested that all errors are still reported to something
+# like application logs, since entirely silencing errors
+# can make debugging problems tricky.
+#
+# Usage:
+#
+#   Sidekiq.configure_server do |config|
+#     config.error_handlers << Amigo::RateLimitedErrorHandler.new(
+#       Sentry::Sidekiq::ErrorHandler.new,
+#       sample_rate: ENV.fetch('ASYNC_ERROR_RATE_LIMITER_SAMPLE_RATE', '0.5').to_f,
+#       ttl: ENV.fetch('ASYNC_ERROR_RATE_LIMITER_TTL', '120').to_f,
+#     )
+#   end
+#
+# See notes about +sample_rate+ and +ttl+,
+# and +fingerprint+ for how exceptions are fingerprinted for uniqueness.
+#
+# Rate limiting is done in-memory so is unique across the entire process-
+# threads/workers share rate limiting, but multiple processes do not.
+# So if 2 processes have 10 threads each,
+# the error handler would be invoked twice if they all error
+# for the same reason.
+#
+# Thread-based limiting (20 errors in the case above)
+# or cross-process limiting (1 error in the case above)
+# can be added in the future.
+module Amigo
+  class RateLimitedErrorHandler
+    # The error handler that will be called to report the error.
+    attr_reader :wrapped
+
+    # After the first error with a fingerprint is seen,
+    # how many future errors with the same fingerprint should we sample,
+    # until the fingerprint expires +ttl+ after the first error?
+    # Use 1 to called the wrapped handler on all errors with the same fingerprint,
+    # and 0 to never call the wrapped handler on those errors until ttl has elapsed.
+    attr_reader :sample_rate
+
+    # How long does the fingerprint live for an error?
+    # For example, with a sample rate of 0 and a ttl of 2 minutes,
+    # the rate will be at most one of the same error every 2 minutes;
+    # the error is always sent when the key is set; then no events are sent until the key expires.
+    #
+    # Note that, unlike Redis TTL, the ttl is set only when the error is first seen
+    # (and then after it's seen once the fingerprint expires);
+    # this means that, if an error is seen once a minute, with a TTL of 2 minutes,
+    # even with a sample rate of 0, an error is recorded every 2 minutes,
+    # rather than just once and never again.
+    attr_reader :ttl
+
+    def initialize(wrapped, sample_rate: 0.1, ttl: 120)
+      @mutex = Mutex.new
+      @wrapped = wrapped
+      @sample_rate = sample_rate
+      @inverse_sample_rate = 1 - @sample_rate
+      @ttl = ttl
+      # Key is fingerprint, value is when to expire
+      @store = {}
+      # Add some fast-paths to handle 0 and 1 sample rates.
+      @call = if sample_rate == 1
+                ->(*a) { @wrapped.call(*a) }
+      elsif sample_rate.zero?
+        self.method(:call_zero)
+      else
+        self.method(:call_sampled)
+      end
+    end
+
+    def call(ex, context)
+      @call[ex, context]
+    end
+
+    private def call_zero(ex, context)
+      call_impl(ex, context) { false }
+    end
+
+    private def call_sampled(ex, context)
+      call_impl(ex, context) { rand <= @sample_rate }
+    end
+
+    private def call_impl(ex, context)
+      now = Time.now
+      invoke = @mutex.synchronize do
+        @store.delete_if { |_sig, t| t < now }
+        fingerprint = self.fingerprint(ex)
+        if @store.key?(fingerprint)
+          yield
+        else
+          @store[fingerprint] = now + @ttl
+          true
+        end
+      end
+      @wrapped.call(ex, context) if invoke
+    end
+
+    # Fingerprint an exception.
+    # - No two exceptions with the same class can be the same.
+    # - If an exception has no backtrace (it was manually constructed),
+    #   the identity of the exception instance (object_id) is the fingerprint.
+    # - If an exception has a backtrace,
+    #   the md5 of the backtrace is the fingerprint.
+    def fingerprint(ex)
+      md5 = Digest::MD5.new
+      md5.update ex.class.to_s
+      if ex.backtrace.nil?
+        md5.update ex.object_id.to_s
+      else
+        ex.backtrace.each { |line| md5.update(line) }
+      end
+      md5.update(self.fingerprint(ex.cause)) if ex.cause
+      return md5.hexdigest
+    end
+  end
+end

--- a/lib/amigo/retry.rb
+++ b/lib/amigo/retry.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "sidekiq"
+
+# Middleware so Sidekiq workers can use a custom retry logic.
+# See +Amigo::Retry::Retry+, +Amigo::Retry::Die+,
+# and +Amigo::Retry::OrDie+ for more details
+# on how these should be used.
+#
+# NOTE: You MUST register +Amigo::Retry::ServerMiddleware+,
+# and you SHOULD increase the size of the dead set if you are relying on 'die' behavior:
+#
+#   Sidekiq.configure_server do |config|
+#     config.options[:dead_max_jobs] = 999_999_999
+#     config.server_middleware.add(Amigo::Retry::ServerMiddleware)
+#   end
+module Amigo
+  module Retry
+    class Error < StandardError; end
+
+    # Raise this class, or a subclass of it, to schedule a later retry,
+    # rather than using an error to trigger Sidekiq's default retry behavior.
+    # The benefit here is that it allows a consistent, customizable behavior,
+    # so is better for 'expected' errors like rate limiting.
+    class Retry < Error
+      attr_accessor :interval_or_timestamp
+
+      def initialize(interval_or_timestamp, msg=nil)
+        @interval_or_timestamp = interval_or_timestamp
+        super(msg || "retry job in #{interval_or_timestamp}")
+      end
+    end
+
+    # Raise this class, or a subclass of it, to send the job to the DeadSet,
+    # rather than going through Sidekiq's retry mechanisms.
+    # This allows jobs to hard-fail when there is something like a total outage,
+    # rather than retrying.
+    class Die < Error
+    end
+
+    # Raise this class, or a subclass of it, to:
+    # - Use +Retry+ exception semantics while the current attempt is <= +attempts+, or
+    # - Use +Die+ exception semantics if the current attempt is > +attempts+.
+    class OrDie < Error
+      attr_reader :attempts, :interval_or_timestamp
+
+      def initialize(attempts, interval_or_timestamp, msg=nil)
+        @attempts = attempts
+        @interval_or_timestamp = interval_or_timestamp
+        super(msg || "retry every #{interval_or_timestamp} up to #{attempts} times")
+      end
+    end
+
+    class ServerMiddleware
+      def call(worker, job, _queue)
+        yield
+      rescue Amigo::Retry::Retry => e
+        handle_retry(worker, job, e)
+      rescue Amigo::Retry::Die => e
+        handle_die(worker, job, e)
+      rescue Amigo::Retry::OrDie => e
+        handle_retry_or_die(worker, job, e)
+      end
+
+      def handle_retry(worker, job, e)
+        Sidekiq.logger.info("scheduling_retry")
+        self.amigo_retry_in(worker.class, job, e.interval_or_timestamp)
+      end
+
+      def handle_die(_worker, job, _e)
+        Sidekiq.logger.warn("sending_to_deadset")
+        payload = Sidekiq.dump_json(job)
+        Sidekiq::DeadSet.new.kill(payload, notify_failure: false)
+      end
+
+      def handle_retry_or_die(worker, job, e)
+        retry_count = job.fetch("retry_count", 0)
+        if retry_count <= e.attempts
+          handle_retry(worker, job, e)
+        else
+          handle_die(worker, job, e)
+        end
+      end
+
+      def amigo_retry_in(worker_class, item, interval)
+        # pulled from perform_in
+        int = interval.to_f
+        now = Time.now.to_f
+        ts = (int < 1_000_000_000 ? now + int : int)
+        item["at"] = ts if ts > now
+        item["retry_count"] = item.fetch("retry_count", 0) + 1
+        worker_class.client_push(item)
+      end
+    end
+  end
+end

--- a/lib/amigo/semaphore_backoff_job.rb
+++ b/lib/amigo/semaphore_backoff_job.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "sidekiq"
+
+module Amigo
+  # This is a placeholder until it's migrated to Amigo proper
+end
+
+# Semaphore backoff jobs can reschedule themselves to happen at a later time
+# if there is too high a contention on a semaphore.
+# Ie, if there are too many jobs with the same key,
+# they start to reschedule themselves for the future.
+#
+# This is useful when a certain job (or job for a certain target)
+# can be slow so should not consume all available resources.
+#
+# In general, you should not use semaphore backoff jobs for singletons,
+# as the guarantees are not strong enough.
+# It is useful for many rapid jobs.
+#
+# Implementers must override the following methods:
+#
+# - `semaphore_key` must return the Redis key to use as the semaphore.
+#   This may be something like "sbj-user-1" to limit jobs for user 1.
+# - `semaphore_size` is the number of concurrent jobs.
+#   Returning 5 would mean at most 5 jobs could be running at a time.
+#
+# And may override the following methods:
+#
+# - `semaphore_backoff` is called to know when to schedule the backoff retry.
+#   By default, it is 10 seconds, plus between 0 and 10 seconds more,
+#   so the job will be retried in between 10 and 20 seconds.
+#   Return whatever you want for the backoff.
+# - `semaphore_expiry` should return the TTL of the semaphore key.
+#   Defaults to 30 seconds. See below for key expiry and negative semaphore value details.
+# - `before_perform` is called before calling the `perform` method.
+#   This is required so that implementers can set worker state, based on job arguments,
+#   that can be used for calculating the semaphore key.
+#
+# Note that we give the semaphore key an expiry. This is to avoid situation where
+# jobs are killed, the decrement is not done, and the counter increases to the point we
+# have fewer than the expected number of jobs running.
+#
+# This does mean that, when a job runs longer than the semaphore expiry,
+# another worker can be started, which would increment the counter back to 1.
+# When the original job ends, the counter would be 0; then when the new job ends,
+# the counter would be -1. To avoid negative counters (which create the same issue
+# around missing decrements), if we ever detect a negative 'jobs running',
+# we warn and remove the key entirely.
+#
+module Amigo
+  module SemaphoreBackoffJob
+    def self.included(cls)
+      cls.include InstanceMethods
+      cls.prepend PrependedMethods
+    end
+
+    class << self
+      # Reset class state. Mostly used just for testing.
+      def reset
+        is_testing = defined?(::Sidekiq::Testing) && ::Sidekiq::Testing.enabled?
+        @enabled = !is_testing
+      end
+
+      # Return true if backoff checks are enabled.
+      attr_accessor :enabled
+
+      def enabled?
+        return @enabled
+      end
+    end
+
+    self.reset
+
+    module InstanceMethods
+      def semaphore_key
+        raise NotImplementedError, "must be implemented on worker"
+      end
+
+      def semaphore_size
+        raise NotImplementedError, "must be implemented on worker"
+      end
+
+      def semaphore_backoff
+        return 10 + (rand * 10)
+      end
+
+      def semaphore_expiry
+        return 30
+      end
+    end
+
+    module PrependedMethods
+      def perform(*args)
+        self.before_perform(*args) if self.respond_to?(:before_perform)
+        return super unless ::Amigo::SemaphoreBackoffJob.enabled?
+        key = self.semaphore_key
+        size = self.semaphore_size
+        # Create a simple counter for the semaphore key.
+        # Always increment; also set an expiration if this is the first job.
+        # If we need to retry later, make sure we decrement, then schedule for the future.
+        # If we run it now, decrement the counter afterwards.
+        # If some corruption results in a negative number of jobs in the semaphore,
+        # we can delete the key and get back to a default state
+        # (this can cause problems but the idea is that
+        # we should run at least the configured number of jobs,
+        # and eventually the semaphore key will expire/get rebalanced).
+        jobs_in_semaphore = Sidekiq.redis do |conn|
+          cnt = conn.incr(key)
+          conn.expire(key, self.semaphore_expiry) if cnt == 1
+          cnt
+        end
+        if jobs_in_semaphore > size
+          Sidekiq.redis { |conn| conn.decr(key) }
+          backoff = self.semaphore_backoff
+          self.class.perform_in(backoff, *args)
+          return
+        end
+        begin
+          super
+        ensure
+          Sidekiq.redis do |conn|
+            new_job_count = conn.decr(key)
+            if new_job_count.negative?
+              conn.del(key)
+              Sidekiq.logger.warn("negative_semaphore_backoff_job_count")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/amigo/spec_helpers.rb
+++ b/lib/amigo/spec_helpers.rb
@@ -122,7 +122,7 @@ module Amigo
 
         @missing.each do |event, payload|
           message = "expected a '%s' event to be fired" % [event]
-          message << " with a payload of %p" % [payload] unless payload.nil?
+          message << (" with a payload of %p" % [payload]) unless payload.nil?
           message << " but none was."
 
           messages << message
@@ -132,7 +132,7 @@ module Amigo
           messages << "No events were sent."
         else
           parts = @recorded_events.map(&:inspect)
-          messages << "The following events were recorded: %s" % [parts.join(", ")]
+          messages << ("The following events were recorded: %s" % [parts.join(", ")])
         end
 
         return messages.join("\n")
@@ -142,7 +142,7 @@ module Amigo
         messages = []
         @matched.each do |event, _payload|
           message = "expected a '%s' event not to be fired" % [event]
-          message << " with a payload of %p" % [@expected_payload] if @expected_payload
+          message << (" with a payload of %p" % [@expected_payload]) if @expected_payload
           message << " but one was."
           messages << message
         end

--- a/lib/amigo/spec_helpers.rb
+++ b/lib/amigo/spec_helpers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "amigo"
+require "sidekiq/worker"
 
 module Amigo
   module SpecHelpers
@@ -228,6 +229,74 @@ module Amigo
 
     def perform_async_job(job)
       return PerformAsyncJobMatcher.new(job)
+    end
+
+    # Like a Sidekiq worker's perform_inline,
+    # but allows an arbitrary item to be used, rather than just the
+    # given class and args. For example, when testing,
+    # you may need to assume something like 'retry_count' is in the job payload,
+    # but that can't be included with perform_inline.
+    # This allows those arbitrary job payload fields
+    # to be included when the job is run.
+    module_function def sidekiq_perform_inline(klass, args, item=nil)
+      Sidekiq::Worker::Setter.override_item = item
+      begin
+        klass.perform_inline(*args)
+      ensure
+        Sidekiq::Worker::Setter.override_item = nil
+      end
+    end
+
+    module_function def drain_sidekiq_jobs(q)
+      all_sidekiq_jobs(q).each do |job|
+        klass = job.item.fetch("class")
+        klass = Sidekiq::Testing.constantize(klass) if klass.is_a?(String)
+        sidekiq_perform_inline(klass, job.item["args"], job.item)
+        job.delete
+      end
+    end
+
+    module_function def all_sidekiq_jobs(q)
+      arr = []
+      q.each { |j| arr << j }
+      return arr
+    end
+
+    # Use this middleware to pass an arbitrary callback evaluated before a job runs.
+    # Make sure to call +reset+ after the test.
+    class ServerCallbackMiddleware
+      class << self
+        attr_accessor :callback
+      end
+
+      def self.reset
+        self.callback = nil
+        return self
+      end
+
+      def self.new
+        return self
+      end
+
+      def self.call(worker, job, queue)
+        self.callback[worker, job, queue] if self.callback
+        yield
+      end
+    end
+  end
+end
+
+module ::Sidekiq
+  module Worker
+    class Setter
+      class << self
+        attr_accessor :override_item
+      end
+      def normalize_item(item)
+        result = super
+        result.merge!(self.class.override_item || {})
+        return result
+      end
     end
   end
 end

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop", "~> 1.11")
   s.add_development_dependency("rubocop-performance", "~> 1.10")
   s.add_development_dependency("timecop", "~> 0")
+  s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/spec/amigo/amigo_spec.rb
+++ b/spec/amigo/amigo_spec.rb
@@ -8,6 +8,9 @@ require "amigo/scheduled_job"
 require "amigo/deprecated_jobs"
 
 RSpec.describe Amigo do
+  before(:all) do
+    Sidekiq::Testing.inline!
+  end
   after(:each) do
     Amigo.reset_logging
   end

--- a/spec/amigo/job_spec.rb
+++ b/spec/amigo/job_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Amigo::Job, :async, :db do
       end
 
       it "does not match if the attribute changes include first_name being set from " \
-        "something that does not match the pattern" do
+         "something that does not match the pattern" do
         expect(matcher).to_not be === {
           "password" => ["foo", "bar"],
           "first_name" => ["James", "Hodintyon"],
@@ -201,7 +201,7 @@ RSpec.describe Amigo::Job, :async, :db do
       end
 
       it "does not match if the attribute changes include email being set to " \
-        "something that does not match the pattern" do
+         "something that does not match the pattern" do
         expect(matcher).to_not be === {
           "password" => ["foo", "bar"],
           "email" => ["wooley@carbuncle.net", "whimsey@lithic.dev"],

--- a/spec/amigo/job_spec.rb
+++ b/spec/amigo/job_spec.rb
@@ -3,6 +3,9 @@
 require "amigo/job"
 
 RSpec.describe Amigo::Job, :async, :db do
+  before(:all) do
+    Sidekiq::Testing.inline!
+  end
   describe "lookup_model" do
     let(:job) do
       Class.new do

--- a/spec/amigo/queue_backoff_job_spec.rb
+++ b/spec/amigo/queue_backoff_job_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "amigo/queue_backoff_job"
+
+RSpec.describe Amigo::QueueBackoffJob do
+  before(:each) do
+    Sidekiq::Testing.fake!
+    described_class.reset
+    described_class.enabled = true
+  end
+
+  after(:each) do
+    Sidekiq::Worker.drain_all
+    described_class.reset
+  end
+
+  nocall = ->(*) { raise "should not be called" }
+
+  def create_job_class(perform:, dependent_queues:, calculate_backoff:)
+    cls = Class.new do
+      include Sidekiq::Worker
+      include Amigo::QueueBackoffJob
+
+      perform && define_method(:perform) do |*args|
+        perform[*args]
+      end
+
+      dependent_queues && define_method(:dependent_queues) do
+        dependent_queues.call
+      end
+
+      calculate_backoff && define_method(:calculate_backoff) do |queue, latency, args|
+        calculate_backoff[queue, latency, args]
+      end
+
+      def self.to_s
+        return "BackoffJob::TestWorker"
+      end
+    end
+    stub_const(cls.to_s, cls)
+    cls
+  end
+
+  def mock_queue(name, latency)
+    q = instance_double(Sidekiq::Queue)
+    expect(q).to receive(:latency).and_return(latency)
+    expect(Sidekiq::Queue).to receive(:new).with(name).and_return(q)
+    return q
+  end
+
+  it "can be enabled and disabled" do
+    described_class.enabled = false
+    calls = []
+    kls = create_job_class(
+      perform: ->(a) { calls << a },
+      dependent_queues: nocall,
+      calculate_backoff: nocall,
+    )
+    kls.perform_async(1)
+    kls.drain
+    expect(calls).to eq([1])
+  end
+
+  it "calls perform if none of the dependent queues have latency" do
+    mock_queue("q1", 0)
+    calls = []
+    kls = create_job_class(
+      perform: ->(a) { calls << a },
+      dependent_queues: -> { ["q1"] },
+      calculate_backoff: nocall,
+    )
+    kls.perform_async(1)
+    kls.drain
+    expect(calls).to eq([1])
+  end
+
+  it "passes the first queue with latency to calculate_backoff" do
+    mock_queue("q1", 0)
+    mock_queue("q2", 1)
+
+    calc_calls = []
+    kls = create_job_class(
+      perform: ->(*) {},
+      dependent_queues: -> { ["q1", "q2"] },
+      calculate_backoff: lambda { |q, lat, args|
+        calc_calls << [q, lat, args]
+        nil
+      },
+    )
+    kls.perform_async(1)
+    kls.drain
+    expect(calc_calls).to eq([["q2", 1, [1]]])
+  end
+
+  it "reschedules via perform_in using the result of calculate_backoff" do
+    mock_queue("q1", 1)
+    kls = create_job_class(
+      perform: nocall,
+      dependent_queues: -> { ["q1", "q2"] },
+      calculate_backoff: ->(*) { 20 },
+    )
+    expect(kls).to receive(:perform_in).with(20, 1)
+    kls.perform_async(1)
+    kls.drain
+  end
+
+  it "checks the remaining queues if calculate_backoff returns nil, falling back to immediate call" do
+    mock_queue("q1", 1)
+    mock_queue("q2", 2)
+    mock_queue("q3", 3)
+    perform_calls = []
+    backoff_calls = []
+    kls = create_job_class(
+      perform: ->(a) { perform_calls << a },
+      dependent_queues: -> { ["q1", "q2", "q3"] },
+      calculate_backoff: lambda { |*args|
+        backoff_calls << args
+        nil
+      },
+    )
+    kls.perform_async(1)
+    kls.drain
+    expect(perform_calls).to eq([1])
+    expect(backoff_calls).to eq([["q1", 1, [1]], ["q2", 2, [1]], ["q3", 3, [1]]])
+  end
+
+  it "does not check remaining queues, and calls perform if calculate_backoff returns <= 0" do
+    mock_queue("q1", 0)
+    mock_queue("q2", 2)
+    perform_calls = []
+    backoff_calls = []
+    kls = create_job_class(
+      perform: ->(a) { perform_calls << a },
+      dependent_queues: -> { ["q1", "q2", "q3"] },
+      calculate_backoff: lambda { |*args|
+        backoff_calls << args
+        0
+      },
+    )
+    kls.perform_async(1)
+    kls.drain
+    expect(perform_calls).to eq([1])
+    expect(backoff_calls).to eq([["q2", 2, [1]]])
+  end
+
+  it "uses the latency as the backoff if less than 10s" do
+    mock_queue("q1", 8)
+    kls = create_job_class(
+      perform: nocall,
+      dependent_queues: -> { ["q1"] },
+      calculate_backoff: nil,
+    )
+    kls.perform_async(1)
+    expect(kls).to receive(:perform_in).with(8, 1)
+    kls.drain
+  end
+
+  it "uses 10s as the default max latency" do
+    mock_queue("q1", 50)
+    kls = create_job_class(
+      perform: nocall,
+      dependent_queues: -> { ["q1"] },
+      calculate_backoff: nil,
+    )
+    kls.perform_async(1)
+    expect(kls).to receive(:perform_in).with(10, 1)
+    kls.drain
+  end
+
+  it "uses all queues, other than the current queue, as the default" do
+    expect(Sidekiq::Queue).to receive(:all).
+      and_return([Sidekiq::Queue.new("q1"), Sidekiq::Queue.new("q2"), Sidekiq::Queue.new("q3")])
+    kls = create_job_class(
+      perform: nocall,
+      dependent_queues: nil,
+      calculate_backoff: nocall,
+    )
+    kls.sidekiq_options queue: "q2"
+    expect(kls.new.dependent_queues).to eq(["q1", "q3"])
+  end
+
+  describe "queue caching" do
+    it "caches the result of all queues" do
+      expect(Sidekiq::Queue).to receive(:all).once.and_return([Sidekiq::Queue.new("q1")])
+      kls = create_job_class(
+        perform: nocall,
+        dependent_queues: nil,
+        calculate_backoff: nocall,
+      )
+      expect(kls.new.dependent_queues).to eq(["q1"])
+      expect(kls.new.dependent_queues).to eq(["q1"])
+    end
+
+    it "can be disabled" do
+      expect(Sidekiq::Queue).to receive(:all).and_return([Sidekiq::Queue.new("q1")])
+      expect(Sidekiq::Queue).to receive(:all).and_return([Sidekiq::Queue.new("q2")])
+      expect(Sidekiq::Queue).to receive(:all).and_return([Sidekiq::Queue.new("q3")])
+      kls = create_job_class(
+        perform: nocall,
+        dependent_queues: nil,
+        calculate_backoff: nocall,
+      )
+      expect(kls.new.dependent_queues).to eq(["q1"])
+      described_class.cache_queue_names = false
+      expect(kls.new.dependent_queues).to eq(["q2"])
+      expect(kls.new.dependent_queues).to eq(["q3"])
+    end
+  end
+
+  describe "latency caching" do
+    it "is enabled by default" do
+      q1 = Sidekiq::Queue.new("q1")
+      expect(q1).to receive(:latency).and_return(3)
+      expect(q1).to receive(:latency).and_return(5)
+      expect(Sidekiq::Queue).to receive(:new).with("q1").twice.and_return(q1)
+
+      now = Time.now
+      expect(described_class.check_latency("q1", now: now)).to eq(3)
+      expect(described_class.check_latency("q1", now: now)).to eq(3)
+      expect(described_class.check_latency("q1", now: now + 6)).to eq(5)
+    end
+
+    it "can be disabled" do
+      described_class.latency_cache_duration = 0
+
+      q1 = Sidekiq::Queue.new("q1")
+      expect(q1).to receive(:latency).and_return(3)
+      expect(q1).to receive(:latency).and_return(5)
+      expect(Sidekiq::Queue).to receive(:new).with("q1").twice.and_return(q1)
+
+      expect(described_class.check_latency("q1")).to eq(3)
+      expect(described_class.check_latency("q1")).to eq(5)
+    end
+  end
+end

--- a/spec/amigo/rate_limited_error_handler_spec.rb
+++ b/spec/amigo/rate_limited_error_handler_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "amigo/rate_limited_error_handler"
+require "timecop"
+
+RSpec.describe Amigo::RateLimitedErrorHandler do
+  reporter_class = Class.new do
+    attr_accessor :reported
+
+    def initialize
+      @reported = []
+    end
+
+    def call(ex, ctx)
+      @reported << [ex, ctx]
+    end
+  end
+  let(:reporter) { reporter_class.new }
+  let(:reported) { reporter.reported }
+
+  # Exceptions are mutable (backtrace) so use let
+  let(:ex) { RuntimeError.new("const") }
+
+  it "always sends the event if the sample rate is 1" do
+    eh = described_class.new(reporter, sample_rate: 1)
+    eh.call(ex, {})
+    eh.call(ex, {})
+    eh.call(ex, {})
+    expect(reported).to have_attributes(length: 3)
+  end
+
+  it "sends only the first event if the sample rate is 0" do
+    eh = described_class.new(reporter, sample_rate: 0)
+    eh.call(ex, {})
+    eh.call(ex, {})
+    eh.call(ex, {})
+    expect(reported).to have_attributes(length: 1)
+  end
+
+  it "skips about half the events after the first if the sample rate is 0.5" do
+    eh = described_class.new(reporter, sample_rate: 0.5)
+    Array.new(500) { eh.call(ex, {}) }
+    expect(reported).to have_attributes(length: be < 500)
+  end
+
+  it "uses the given ttl for the rate limiting key" do
+    now = Time.now
+    eh = described_class.new(reporter, sample_rate: 0, ttl: minutes(60))
+    Timecop.freeze(now) do
+      eh.call(ex, {})
+      expect(reported).to have_attributes(length: 1)
+      eh.call(ex, {}) # Immediate call
+      expect(reported).to have_attributes(length: 1)
+    end
+
+    Timecop.freeze(now + minutes(59)) { eh.call(ex, {}) }
+    expect(reported).to have_attributes(length: 1) # Still too early
+
+    Timecop.freeze(now + minutes(61)) { eh.call(ex, {}) }
+    expect(reported).to have_attributes(length: 2) # TTL expired
+  end
+
+  describe "fingerprint" do
+    it "generates unique fingerprints for exception objects" do
+      eh = described_class.new(reporter)
+      ex1 = RuntimeError.new("ex")
+      ex2 = RuntimeError.new("ex")
+      expect(eh.fingerprint(ex1)).to eq(eh.fingerprint(ex1))
+      expect(eh.fingerprint(ex2)).to_not eq(eh.fingerprint(ex1))
+    end
+
+    it "generates the same fingerprint for exceptions with the same stack traces" do
+      eh = described_class.new(reporter)
+      fingerprints = Set.new
+      Array.new(5) do |x|
+        x / 0
+      rescue ZeroDivisionError => e
+        fingerprints << eh.fingerprint(e)
+      end
+      expect(fingerprints).to have_attributes(size: 1)
+
+      begin
+        1 / 0
+      rescue ZeroDivisionError => e
+        fingerprints << eh.fingerprint(e)
+      end
+      expect(fingerprints).to have_attributes(size: 2)
+    end
+
+    it "ignores the message of exceptions with a backtrace since the message can be volatile" do
+      eh = described_class.new(reporter)
+      fingerprints = Set.new
+      Array.new(5) do |x|
+        nil.send(x.to_sym)
+      rescue NoMethodError => e
+        fingerprints << eh.fingerprint(e)
+      end
+      expect(fingerprints).to have_attributes(size: 1)
+    end
+
+    it "works with manually raised exceptions" do
+      eh = described_class.new(reporter)
+      fingerprints = Set.new
+      e = RuntimeError.new("t")
+      # Raise twice on different lines so there are different stack traces
+      begin
+        raise e
+      rescue RuntimeError => e
+        fingerprints << eh.fingerprint(e)
+      end
+      e.set_backtrace(nil)
+      begin
+        raise e
+      rescue RuntimeError => e
+        fingerprints << eh.fingerprint(e)
+      end
+      expect(fingerprints).to have_attributes(size: 2)
+    end
+
+    it "uses unique fingerprints if the same exception has a different cause" do
+      eh = described_class.new(reporter)
+      fingerprints = Set.new
+      # Must have different types, since they are raised with the same stack trace.
+      cause1 = TypeError.new("c")
+      cause2 = NoMethodError.new("c")
+      [cause1, cause2].each do |c|
+        begin
+          raise c
+        rescue StandardError
+          raise "wrapped"
+        end
+      rescue RuntimeError => e
+        expect(e).to have_attributes(message: "wrapped", cause: be_a(c.class))
+        fingerprints << eh.fingerprint(e)
+      end
+      expect(fingerprints).to have_attributes(size: 2)
+    end
+  end
+
+  def minutes(x)
+    return x * 60
+  end
+end

--- a/spec/amigo/retry_spec.rb
+++ b/spec/amigo/retry_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "amigo/retry"
+
+RSpec.describe Amigo::Retry do
+  before(:each) do
+    Sidekiq.redis(&:flushdb)
+    Sidekiq::Testing.disable!
+    Sidekiq.server_middleware.add(described_class::ServerMiddleware)
+  end
+
+  after(:each) do
+    Sidekiq.server_middleware.remove(described_class::ServerMiddleware)
+    Sidekiq.redis(&:flushdb)
+  end
+
+  def create_job_class(perform: nil, ex: nil, &block)
+    raise "pass :perform or :ex" unless perform || ex
+    cls = Class.new do
+      include Sidekiq::Worker
+
+      define_method(:perform) do |*args|
+        raise ex if ex
+        perform[*args]
+      end
+
+      def self.to_s
+        return "Retry::TestWorker"
+      end
+
+      block && class_eval do
+        yield(self)
+      end
+    end
+    stub_const(cls.to_s, cls)
+    cls
+  end
+
+  it "catches retry exceptions and reschedules with the given interval" do
+    kls = create_job_class(ex: Amigo::Retry::Retry.new(30))
+    kls.perform_async(1)
+
+    expect(all_sidekiq_jobs(Sidekiq::Queue.new)).to have_attributes(length: 1)
+    drain_sidekiq_jobs(Sidekiq::Queue.new)
+
+    expect(all_sidekiq_jobs(Sidekiq::ScheduledSet.new)).to contain_exactly(
+      have_attributes(
+        score: be_within(5).of(Time.now.to_f + 30),
+        item: include("retry_count" => 1),
+      ),
+    )
+
+    # Continue to retry
+    drain_sidekiq_jobs(Sidekiq::ScheduledSet.new)
+    sched2 = all_sidekiq_jobs(Sidekiq::ScheduledSet.new)
+    expect(sched2).to have_attributes(length: 1)
+    expect(sched2.first).to have_attributes(
+      score: be_within(5).of(Time.now.to_f + 30),
+      item: include("retry_count" => 2),
+    )
+  end
+
+  it "retries on the correct queue" do
+    kls = create_job_class(ex: Amigo::Retry::Retry.new(30)) do |cls|
+      cls.sidekiq_options queue: "otherq"
+    end
+    kls.perform_async(1)
+
+    jobs = all_sidekiq_jobs(Sidekiq::Queue.new("otherq"))
+    expect(jobs).to have_attributes(length: 1)
+    drain_sidekiq_jobs(Sidekiq::Queue.new("otherq"))
+
+    # Should have moved to retry set
+    sched = all_sidekiq_jobs(Sidekiq::ScheduledSet.new)
+    expect(sched).to have_attributes(length: 1)
+    expect(sched.first).to have_attributes(queue: "otherq")
+  end
+
+  it "catches die exceptions and sends to the dead set" do
+    kls = create_job_class(ex: Amigo::Retry::Die.new)
+    kls.perform_async(1)
+
+    drain_sidekiq_jobs(Sidekiq::Queue.new)
+
+    # Ends up in dead set, not scheduled set
+    expect(all_sidekiq_jobs(Sidekiq::ScheduledSet.new)).to be_empty
+    dead = all_sidekiq_jobs(Sidekiq::DeadSet.new)
+    expect(dead).to have_attributes(length: 1)
+    expect(dead.first).to have_attributes(klass: kls.name, args: [1])
+  end
+
+  it "can conditionally retry or die depending on the retry count" do
+    kls = create_job_class(ex: Amigo::Retry::OrDie.new(2, 30))
+    kls.perform_async(1)
+
+    drain_sidekiq_jobs(Sidekiq::Queue.new) # will go to be retried
+    expect(all_sidekiq_jobs(Sidekiq::ScheduledSet.new)).to have_attributes(length: 1)
+    drain_sidekiq_jobs(Sidekiq::ScheduledSet.new) # retry once
+    expect(all_sidekiq_jobs(Sidekiq::ScheduledSet.new)).to have_attributes(length: 1)
+    drain_sidekiq_jobs(Sidekiq::ScheduledSet.new) # retry twice
+    expect(all_sidekiq_jobs(Sidekiq::ScheduledSet.new)).to have_attributes(length: 1)
+    drain_sidekiq_jobs(Sidekiq::ScheduledSet.new) # the third retry moves to the dead set
+    expect(all_sidekiq_jobs(Sidekiq::DeadSet.new)).to have_attributes(length: 1)
+  end
+end

--- a/spec/amigo/semaphore_backoff_job_spec.rb
+++ b/spec/amigo/semaphore_backoff_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "amigo/semaphore_backoff_job"
+
+RSpec.describe Amigo::SemaphoreBackoffJob do
+  before(:each) do
+    Sidekiq::Testing.disable!
+    described_class.reset
+    described_class.enabled = true
+    Sidekiq.redis(&:flushdb)
+  end
+
+  after(:each) do
+    described_class.reset
+  end
+
+  nocall = ->(*) { raise "should not be called" }
+
+  def create_job_class(perform:, key: "semkey", size: 5, &block)
+    cls = Class.new do
+      include Sidekiq::Worker
+      include Amigo::SemaphoreBackoffJob
+
+      define_method(:perform) { |*args| perform[*args] }
+      define_method(:semaphore_key) { key }
+      define_method(:semaphore_size) { size }
+
+      def self.to_s
+        return "SemaphoreBackoffJob::TestWorker"
+      end
+
+      block && class_eval do
+        yield(self)
+      end
+    end
+    stub_const(cls.to_s, cls)
+    cls
+  end
+
+  it "can be enabled and disabled" do
+    described_class.enabled = false
+    calls = []
+    kls = create_job_class(perform: ->(a) { calls << a }, key: nocall, size: nocall)
+    sidekiq_perform_inline(kls, [1])
+    expect(calls).to eq([1])
+  end
+
+  it "calls perform if the semaphore is below max size" do
+    calls = []
+    kls = create_job_class(perform: ->(a) { calls << a })
+    sidekiq_perform_inline(kls, [1])
+    expect(calls).to eq([1])
+    Sidekiq.redis do |c|
+      expect(c.get("semkey")).to eq("0")
+      expect(c.ttl("semkey")).to eq(30)
+    end
+  end
+
+  it "only sets key expiry for the first job taking the semaphore" do
+    Sidekiq.redis do |c|
+      c.setex("semkey", 100, "1") # Pretend the semaphore is already taken, and we check the TTL later
+    end
+    calls = []
+    kls = create_job_class(perform: ->(a) { calls << a })
+    sidekiq_perform_inline(kls, [1])
+    expect(calls).to eq([1])
+    Sidekiq.redis do |c|
+      expect(c.ttl("semkey")).to be_within(10).of(100)
+    end
+  end
+
+  it "invokes before_perform if provided" do
+    calls = []
+    kls = create_job_class(perform: ->(a) { calls << a }) do |this|
+      this.define_method(:before_perform) do |args|
+        @args = args
+      end
+      this.define_method(:semaphore_key) do
+        "k-#{@args}"
+      end
+    end
+    sidekiq_perform_inline(kls, ["myarg"])
+    expect(calls).to eq(["myarg"])
+  end
+
+  it "reschedules via perform_in using the result of sempahore_backoff" do
+    Sidekiq.redis do |c|
+      c.set("semkey", 5) # Semaphore is at max size
+    end
+    kls = create_job_class(perform: nocall) do |this|
+      this.define_method(:semaphore_backoff) do
+        6
+      end
+    end
+    expect(kls).to receive(:perform_in).with(6, 1)
+    sidekiq_perform_inline(kls, [1])
+  end
+
+  it "reschedules with a default semaphore backoff" do
+    Sidekiq.redis do |c|
+      c.set("semkey", 5) # Semaphore is at max size
+    end
+    kls = create_job_class(perform: nocall)
+    expect(kls).to receive(:perform_in).with((be >= 10).and(be <= 20), 1)
+    sidekiq_perform_inline(kls, [1])
+  end
+
+  it "expires the key if the decrement returns a negative value" do
+    Sidekiq.redis do |c|
+      c.set("semkey", "-1")
+    end
+    calls = []
+    kls = create_job_class(perform: ->(a) { calls << a })
+    sidekiq_perform_inline(kls, [1])
+    expect(calls).to eq([1])
+    expect(Sidekiq.redis { |c| c.exists("semkey") }).to eq(0)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,8 @@ require "rspec/support/object_formatter"
 require "sidekiq/testing"
 require "amigo/spec_helpers"
 
-Sidekiq::Testing.inline!
-
 RSpec.configure do |config|
-  # config.full_backtrace = true
+  config.full_backtrace = true
 
   RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 600
 
@@ -31,4 +29,19 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.default_formatter = "doc" if config.files_to_run.one?
   config.include(Amigo::SpecHelpers)
+
+  Sidekiq.configure_server do |sdkqcfg|
+    sdkqcfg.redis = {url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:22379/0")}
+  end
+  Sidekiq.configure_client do |sdkqcfg|
+    sdkqcfg.redis = {url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:22379/0")}
+  end
+end
+
+# See https://github.com/mperham/sidekiq/issues/5510
+# Once it's fixed we can remove.
+class String
+  def constantize
+    return Sidekiq::Testing.constantize(self)
+  end
 end


### PR DESCRIPTION
- `Retry` can be used for custom retry behavior,
  where the code being run, and not the queue,
  needs to specify how something should retry and die.
- `QueueBackoffJob` can be used to reschedule a job before it runs
  if another queue has latency (avoid saturing all worker threads
  with a single queue).
- `RateLimitedErrorHandler` is used to avoid handling the same error
  many times over within the same process, to avoid error spam.
- `SemaphoreBackoffJob` is used to run a job under a semaphore key
  to avoid more concurrency than desired (ie avoid a single user
  saturating all worker threads).
- Spec helpers for working with a real Redis

