### PR TITLE
Better handling of failure cases like Redis being down

### DIFF
--- a/lib/amigo.rb
+++ b/lib/amigo.rb
@@ -140,7 +140,18 @@ module Amigo
     # An Array of callbacks to be run when an event is published.
     attr_accessor :subscribers
 
-    # A single callback to be run when an event publication errors.
+    # A single callback to be run when an event publication errors,
+    # almost always due to an error in a subscriber.
+    #
+    # The callback receives the exception, the event being published, and the erroring subscriber.
+    #
+    # If this is not set, errors from subscribers will be re-raised immediately,
+    # since broken subscribers usually indicate a broken application.
+    #
+    # Note also that when an error occurs, Amigo.log is always called first.
+    # You do NOT need a callback that just logs and swallows the error.
+    # If all you want to do is log, and not propogate the error,
+    # you can use `Amigo.on_publish_error = proc {}`.
     attr_accessor :on_publish_error
 
     # Publish an event with the specified +eventname+ and +payload+
@@ -151,12 +162,18 @@ module Amigo
       self.subscribers.to_a.each do |hook|
         hook.call(ev)
       rescue StandardError => e
-        self.log(nil, :error, "amigo_subscriber_hook_error", error: e, hook: hook, event: ev)
-        self.on_publish_error.call(e)
+        self.log(nil, :error, "amigo_subscriber_hook_error", error: e, hook: hook, event: ev&.as_json)
+        raise e if self.on_publish_error.nil?
+        if self.on_publish_error.respond_to?(:arity) && self.on_publish_error.arity == 1
+          self.on_publish_error.call(e)
+        else
+          self.on_publish_error.call(e, ev, hook)
+        end
       end
     end
 
     # Register a hook to be called when an event is sent.
+    # If a subscriber errors, on_publish_error is called with the exception, event, and subscriber.
     def register_subscriber(&block)
       raise LocalJumpError, "no block given" unless block
       self.log nil, :info, "amigo_installed_subscriber", block: block
@@ -272,7 +289,6 @@ Amigo.reset_logging
 Amigo.synchronous_mode = false
 Amigo.registered_jobs = []
 Amigo.subscribers = Set.new
-Amigo.on_publish_error = proc {}
 
 require "amigo/audit_logger"
 require "amigo/router"

--- a/spec/amigo/amigo_spec.rb
+++ b/spec/amigo/amigo_spec.rb
@@ -9,17 +9,6 @@ require "amigo/deprecated_jobs"
 require_relative "helpers"
 
 RSpec.describe Amigo do
-  before(:all) do
-    Sidekiq::Testing.inline!
-  end
-  before(:each) do
-    Amigo.on_publish_error = nil
-    Amigo.subscribers.clear
-  end
-  after(:each) do
-    Amigo.reset_logging
-  end
-
   describe "log" do
     it "respects structured logging" do
       publishes = []

--- a/spec/amigo/audit_logger_spec.rb
+++ b/spec/amigo/audit_logger_spec.rb
@@ -4,28 +4,32 @@ require "amigo/audit_logger"
 require "amigo/job"
 
 RSpec.describe Amigo::AuditLogger, :async do
-  before(:all) do
-    Sidekiq::Testing.inline!
-  end
-
-  let(:noop_job) do
-    Class.new do
-      extend Amigo::Job
-      def _perform(*); end
-    end
+  before(:each) do
+    @logged = []
+    Amigo.structured_logging = true
+    Amigo.log_callback = ->(*args) { @logged << args }
+    Amigo.install_amigo_jobs
   end
 
   it "logs all events once" do
-    logged = nil
-    Amigo.structured_logging = true
-    Amigo.log_callback = ->(*args) { logged = args }
+    Amigo.publish("some.event", 123)
+    expect(@logged).to include(
+      [
+        be_a(Amigo::AuditLogger),
+        :info,
+        "async_job_audit",
+        {event_id: be_a(String), event_name: "some.event", event_payload: [123]},
+      ],
+    )
+  end
 
-    expect do
-      Amigo.publish("some.event", 123)
-    end.to perform_async_job(noop_job)
-    expect(logged).to match_array(
-      [be_a(Amigo::AuditLogger), :info, "async_job_audit",
-       {event_id: be_a(String), event_name: "some.event", event_payload: [123]},],
+  it "runs synchronously if the audit logger job cannot be scheduled to perform async" do
+    ex = RuntimeError.new("redis error")
+    expect(described_class).to receive(:perform_async).and_raise(ex)
+    Amigo.publish("some.event", 123)
+    expect(@logged).to include(
+      [nil, :error, "amigo_audit_log_subscriber_error", hash_including(error: ex, event: be_a(Hash))],
+      [be_a(Amigo::AuditLogger), :info, "async_job_audit", hash_including(:event_id, :event_name, :event_payload)],
     )
   end
 end

--- a/spec/amigo/helpers.rb
+++ b/spec/amigo/helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Amigo
+  module Test; end
+end
+
+module Amigo
+  module Test
+    class Spy
+      attr_reader :calls
+
+      def initialize
+        @calls = []
+      end
+
+      def call(*args)
+        @calls << args
+      end
+    end
+  end
+end

--- a/spec/amigo/job_spec.rb
+++ b/spec/amigo/job_spec.rb
@@ -3,9 +3,6 @@
 require "amigo/job"
 
 RSpec.describe Amigo::Job, :async, :db do
-  before(:all) do
-    Sidekiq::Testing.inline!
-  end
   describe "lookup_model" do
     let(:job) do
       Class.new do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,17 @@ RSpec.configure do |config|
   Sidekiq.configure_client do |sdkqcfg|
     sdkqcfg.redis = {url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:22379/0")}
   end
+
+  config.before(:all) do
+    Sidekiq::Testing.inline!
+  end
+  config.before(:each) do
+    Amigo.on_publish_error = nil
+    Amigo.subscribers.clear
+  end
+  config.after(:each) do
+    Amigo.reset_logging
+  end
 end
 
 # See https://github.com/mperham/sidekiq/issues/5510


### PR DESCRIPTION
Handle audit logger perform_async failure

Fixes #6

If the audit logger job cannot `perform_async`,
we would get an error in the subscriber.
This is not great, since it means we don't get the event audited.

Instead, if we cannot `.perform_async` we can `.new.perform`.
This ensures we still get the event audited,
even if Redis is down.

---

Refactor some spec setup duplication

---

Better handling of errors in subscribers

Fixes #5

We were not handling subscriber errors aggressively enough.
The idea was that, because publish and subscribe are decoupled,
a failure in a subscriber should NOT be a critical error
in the app- it should be a failure of just that subscriber.
And we log the error out of convenience.

This makes sense in theory, in a truly distributed pub/sub system,
but in practice, clients depend on subscriptions to publish
properly; for example, if model events fail to publish
(because, say, they enqueue a job into Redis)
many critical components of a system will not work.

Instead, the default behavior should be to raise an error
if any subscriber fails. This would cause code that fails to publish
to raise an error on the `publish` call, returning a 500,
failing the job, etc.

To continue the old behavior,
you can use `Amigo.on_publish_error = proc {}`.

This also improves the logging so that we log the full event details,
rather than just the representation of the object.
This means that, if something critical fails to publish,
there is still a record of the event for future use in repairs.

