### PR TITLE
Add Amigo::Autoscaler

### DIFF
--- a/lib/amigo/autoscaler.rb
+++ b/lib/amigo/autoscaler.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "sidekiq/api"
+
+require "amigo"
+
+# When queues achieve a latency that is too high,
+# take some action.
+# You should start this up at Sidekiq application startup:
+#
+# # sidekiq.rb
+# Amigo::Autoscaler.new.start
+#
+# Right now, this is pretty simple- we alert any time
+# there is a latency over a threshold.
+#
+# In the future, we can:
+#
+# 1) actually autoscale rather than just alert
+#    (this may take the form of a POST to a configurable endpoint),
+# 2) become more sophisticated with how we detect latency growth.
+#
+module Amigo
+  class Autoscaler
+    class InvalidHandler < StandardError; end
+
+    # How often should Autoscaler check for latency?
+    # @return [Integer]
+    attr_reader :poll_interval
+    # What latency should we alert on?
+    # @return [Integer]
+    attr_reader :latency_threshold
+    # What hosts/processes should this run on?
+    # Look at ENV['DYNO'] and Socket.gethostname.
+    # Default to only run on 'web.1', which is the first Heroku web dyno.
+    # We run on the web, not worker, dyno, so we report backed up queues
+    # in case we, say, turn off all workers (broken web processes
+    # are generally easier to find).
+    # @return [Regexp]
+    attr_reader :hostname_regex
+    # Methods to call when alerting.
+    # Valid values are 'log' and 'sentry' (requires Sentry to be required already).
+    # Anything that responds to +call+ will be invoked with a hash of
+    # `{queue name => latency in seconds}`.
+    # @return [Array<String,Proc>]
+    attr_reader :handlers
+    # Only alert this often.
+    # For example, with poll_interval of 10 seconds
+    # and alert_interval of 200 seconds,
+    # we'd alert once and then 210 seconds later.
+    # @return [Integer]
+    attr_reader :alert_interval
+
+    def initialize(
+      poll_interval: 20,
+      latency_threshold: 5,
+      hostname_regex: /^web\.1$/,
+      handlers: ["log"],
+      alert_interval: 120
+    )
+
+      @poll_interval = poll_interval
+      @latency_threshold = latency_threshold
+      @hostname_regex = hostname_regex
+      @handlers = handlers
+      @alert_interval = alert_interval
+    end
+
+    def polling_thread
+      return @polling_thread
+    end
+
+    def setup
+      # Store these as strings OR procs, rather than grabbing self.method here.
+      # It gets extremely hard ot test if we capture the method here.
+      @alert_methods = self.handlers.map do |a|
+        if a.respond_to?(:call)
+          a
+        else
+          method_name = meth = "alert_#{a.strip}".to_sym
+          raise InvalidHandler, a.inspect unless self.method(method_name)
+          meth
+        end
+      end
+      @last_alerted = Time.at(0)
+      @stop = false
+    end
+
+    def start
+      raise "already started" unless @polling_thread.nil?
+
+      hostname = ENV.fetch("DYNO") { Socket.gethostname }
+      return false unless self.hostname_regex.match?(hostname)
+
+      self.log(:info, "async_autoscaler_starting")
+      self.setup
+      @polling_thread = Thread.new do
+        until @stop
+          Kernel.sleep(self.poll_interval)
+          self.check unless @stop
+        end
+      end
+      return true
+    end
+
+    def stop
+      @stop = true
+    end
+
+    def check
+      now = Time.now
+      skip_check = now < (@last_alerted + self.poll_interval)
+      if skip_check
+        self.log(:debug, "async_autoscaler_skip_check")
+        return
+      end
+      self.log(:info, "async_autoscaler_check")
+      high_latency_queues = Sidekiq::Queue.all.
+        map { |q| [q.name, q.latency] }.
+        select { |(_, latency)| latency > self.latency_threshold }.
+        to_h
+      return if high_latency_queues.empty?
+      @alert_methods.each do |m|
+        m.respond_to?(:call) ? m.call(high_latency_queues) : self.send(m, high_latency_queues)
+      end
+      @last_alerted = now
+    end
+
+    def alert_sentry(names_and_latencies)
+      Sentry.with_scope do |scope|
+        scope.set_extras(high_latency_queues: names_and_latencies)
+        names = names_and_latencies.map(&:first).sort.join(", ")
+        Sentry.capture_message("Some queues have a high latency: #{names}")
+      end
+    end
+
+    def alert_log(names_and_latencies)
+      self.log(:warn, "high_latency_queues", queues: names_and_latencies)
+    end
+
+    def alert_test(_names_and_latencies); end
+
+    protected def log(level, msg, **kw)
+      Amigo.log(nil, level, msg, kw)
+    end
+  end
+end

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec-core", "~> 3.10")
   s.add_development_dependency("rubocop", "~> 1.11")
   s.add_development_dependency("rubocop-performance", "~> 1.10")
+  s.add_development_dependency("sentry-ruby", "~> 5")
   s.add_development_dependency("timecop", "~> 0")
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/spec/amigo/autoscaler_spec.rb
+++ b/spec/amigo/autoscaler_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "timecop"
+
+require "amigo/autoscaler"
+
+RSpec.describe Amigo::Autoscaler do
+  def instance(**kw)
+    described_class.new(poll_interval: 0, handlers: ["test"], **kw)
+  end
+
+  before(:all) do
+    Sidekiq::Testing.inline!
+    @dyno = ENV.fetch("DYNO", nil)
+  end
+
+  after(:each) do
+    ENV["DYNO"] = @dyno
+  end
+
+  def fake_q(name, latency)
+    cls = Class.new do
+      define_method(:name) { name }
+      define_method(:latency) { latency }
+    end
+    return cls.new
+  end
+
+  describe "start" do
+    it "starts a polling thread if the dyno env var matches the given regex" do
+      allow(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 0)])
+
+      ENV["DYNO"] = "foo.123"
+      o = instance(hostname_regex: /^foo\.123$/)
+      expect(o.start).to be_truthy
+      expect(o.polling_thread).to be_a(Thread)
+      o.polling_thread.kill
+
+      o = instance
+      ENV["DYNO"] = "foo.12"
+      expect(o.start).to be_falsey
+      expect(o.polling_thread).to be_nil
+    end
+
+    it "starts a polling thread if the hostname matches the given regex" do
+      allow(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 0)])
+
+      expect(Socket).to receive(:gethostname).and_return("foo.123")
+      o = instance(hostname_regex: /^foo\.123$/)
+      expect(o.start).to be_truthy
+      expect(o.polling_thread).to be_a(Thread)
+      o.polling_thread.kill
+
+      expect(Socket).to receive(:gethostname).and_return("foo.12")
+      o = instance
+      expect(o.start).to be_falsey
+      expect(o.polling_thread).to be_nil
+    end
+  end
+
+  describe "check" do
+    it "noops if there are no high latency queues" do
+      expect(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 1)])
+      o = instance
+      expect(o).to_not receive(:alert_test)
+      o.setup
+      o.check
+    end
+
+    it "alerts about high latency queues" do
+      expect(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 1), fake_q("y", 20)])
+      o = instance
+      expect(o).to receive(:alert_test).with({"y" => 20})
+      o.setup
+      o.check
+    end
+
+    it "noops if recently alerted" do
+      expect(Sidekiq::Queue).to receive(:all).
+        twice.
+        and_return([fake_q("x", 1), fake_q("y", 20)])
+      now = Time.now
+      o = instance(poll_interval: 120)
+      o.setup
+      expect(o).to receive(:alert_test).twice
+      Timecop.freeze(now) { o.check }
+      Timecop.freeze(now + 60) { o.check }
+      Timecop.freeze(now + 180) { o.check }
+    end
+  end
+
+  describe "alert_log" do
+    after(:each) do
+      Amigo.reset_logging
+    end
+
+    it "logs" do
+      Amigo.structured_logging = true
+      expect(Amigo.log_callback).to receive(:[]).
+        with(nil, :warn, "high_latency_queues", {queues: {"x" => 11, "y" => 24}})
+      instance.alert_log({"x" => 11, "y" => 24})
+    end
+  end
+
+  describe "alert_sentry" do
+    before(:each) do
+      require "sentry-ruby"
+      @main_hub = Sentry.get_main_hub
+      Sentry.init do |config|
+        config.dsn = "http://public:secret@not-really-sentry.nope/someproject"
+      end
+    end
+
+    after(:each) do
+      Sentry.instance_variable_set(:@main_hub, nil)
+    end
+
+    it "calls Sentry" do
+      expect(Sentry.get_current_client).to receive(:capture_event).
+        with(
+          have_attributes(message: "Some queues have a high latency: x, y"),
+          have_attributes(extra: {high_latency_queues: {"x" => 11, "y" => 24}}),
+          include(:message),
+        )
+      instance.alert_sentry({"x" => 11, "y" => 24})
+    end
+  end
+
+  describe "alert callable" do
+    it "calls the callable" do
+      expect(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 1), fake_q("y", 20)])
+      called_with = nil
+      handler = proc do |arg|
+        called_with = arg
+      end
+      o = instance(handlers: [handler])
+      o.setup
+      o.check
+      expect(called_with).to eq({"y" => 20})
+    end
+  end
+end


### PR DESCRIPTION
Can be used to respond to slow queues, right now only by alerting.

We've been using this in WebhookDB for a while and it's been useful.