### PR TITLE
Allow regular expression patterns in jobs

### DIFF
--- a/lib/amigo.rb
+++ b/lib/amigo.rb
@@ -57,6 +57,10 @@ require "sidekiq-cron"
 # The 'on' pattern can be 'myapp.customer.*' to match all customer events for example,
 # or '*' to match all events. The rules of matching follow File.fnmatch.
 #
+# The 'on' pattern accepts regular expressions '/myapp\.customer\.created&/' to only match specific
+# events like created. This allows 'myapp.customer.created' event name to be handled differently from
+# 'myapp.customer.subresource.created'. The rules of matching follow Regexp#match method.
+#
 # Jobs must implement a `_perform` method, which takes a Amigo::Event.
 # Note that normal Sidekiq workers use a 'perform' method that takes a variable number of arguments;
 # the base Async::Job class has this method and delegates its business logic to the subclass _perform method.

--- a/lib/amigo.rb
+++ b/lib/amigo.rb
@@ -57,9 +57,8 @@ require "sidekiq-cron"
 # The 'on' pattern can be 'myapp.customer.*' to match all customer events for example,
 # or '*' to match all events. The rules of matching follow File.fnmatch.
 #
-# The 'on' pattern accepts regular expressions '/myapp\.customer\.created&/' to only match specific
-# events like created. This allows 'myapp.customer.created' event name to be handled differently from
-# 'myapp.customer.subresource.created'. The rules of matching follow Regexp#match method.
+# The 'on' pattern also accepts regular expressions, like /^myapp\.customer\.[a-z]+$/,
+# to control the matching rules more closely than File.fnmatch can provide.
 #
 # Jobs must implement a `_perform` method, which takes a Amigo::Event.
 # Note that normal Sidekiq workers use a 'perform' method that takes a variable number of arguments;

--- a/lib/amigo/router.rb
+++ b/lib/amigo/router.rb
@@ -12,8 +12,8 @@ module Amigo
       event_name = event_json["name"]
       matches = Amigo.registered_event_jobs.
         select do |job|
-        if job.pattern.instance_of?(Regexp)
-          !Regexp.new(job.pattern).match(event_name).nil?
+        if job.pattern.is_a?(Regexp)
+          job.pattern.match(event_name)
         else
           File.fnmatch(job.pattern, event_name, File::FNM_EXTGLOB)
         end

--- a/lib/amigo/router.rb
+++ b/lib/amigo/router.rb
@@ -11,7 +11,13 @@ module Amigo
     def perform(event_json)
       event_name = event_json["name"]
       matches = Amigo.registered_event_jobs.
-        select { |job| File.fnmatch(job.pattern, event_name, File::FNM_EXTGLOB) }
+        select do |job|
+        if job.pattern.instance_of?(Regexp)
+          !Regexp.new(job.pattern).match(event_name).nil?
+        else
+          File.fnmatch(job.pattern, event_name, File::FNM_EXTGLOB)
+        end
+      end
       matches.each do |job|
         Amigo.synchronous_mode ? job.new.perform(event_json) : job.perform_async(event_json)
       end

--- a/spec/amigo/amigo_spec.rb
+++ b/spec/amigo/amigo_spec.rb
@@ -191,6 +191,22 @@ RSpec.describe Amigo do
       end.to perform_async_job(job)
       expect(job.result).to be_nil
     end
+
+    it "runs jobs with a regular expression pattern matching a publish event" do
+      job.pattern = /foo\.bar\.created$/
+      expect do
+        Amigo.publish("foo.bar.created", 123)
+      end.to perform_async_job(job)
+      expect(job.result).to have_attributes(payload: [123], name: "foo.bar.created", id: be_a(String))
+    end
+
+    it "does not perform work for published events not matching the regular expression pattern" do
+      job.pattern = /foo\.bar\.subresource$/
+      expect do
+        Amigo.publish("foo.bar.subresource.created", 123)
+      end.to perform_async_job(job)
+      expect(job.result).to be_nil
+    end
   end
 
   describe "register_job" do


### PR DESCRIPTION
Fixes #10

- Allow regular expression job patterns to match more specific events (check issues for more information)