### PR TITLE
Support `splay nil` to disable splay behavior

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 2.7
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 Layout/CaseIndentation:

--- a/spec/amigo/amigo_spec.rb
+++ b/spec/amigo/amigo_spec.rb
@@ -293,6 +293,22 @@ RSpec.describe Amigo do
       expect(args).to eq([true] * 20)
     end
 
+    it "executes immediately when splay is nil" do
+      calls = []
+      job = Class.new do
+        extend Amigo::ScheduledJob
+        cron "* * * * *"
+        splay nil
+        define_method(:_perform) do
+          calls << true
+        end
+      end
+
+      expect(job).to_not receive(:perform_in)
+      Array.new(20) { job.new.perform }
+      expect(calls).to eq([true] * 20)
+    end
+
     it "executes its inner _perform when performed with true" do
       performed = false
       job = Class.new do


### PR DESCRIPTION
Useful for very frequently-running scheduled jobs.