### PR TITLE
publish matcher can accept a matcher as a topic

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.3', '3.2', '3.1', '3.0']
     services:
       redis:
         image: redis

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,9 @@ require:
   - rubocop-performance
 
 AllCops:
-  NewCops: enable
+  NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Gemspec/DevelopmentDependencies:
   Enabled: false
@@ -87,6 +87,8 @@ Style/Documentation:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: percent
+Style/HashEachMethods:
+  Enabled: false
 Style/NumericPredicate:
   AllowedMethods: ['where']
 Style/RedundantReturn:

--- a/lib/amigo/spec_helpers.rb
+++ b/lib/amigo/spec_helpers.rb
@@ -101,7 +101,8 @@ module Amigo
       def match_expected_events
         @expected_events.each do |expected_event, expected_payload|
           match = @recorded_events.find do |recorded|
-            recorded.name == expected_event && self.payloads_match?(expected_payload, recorded.payload)
+            self.event_names_match?(expected_event, recorded.name) &&
+              self.payloads_match?(expected_payload, recorded.payload)
           end
 
           if match
@@ -112,9 +113,15 @@ module Amigo
         end
       end
 
-      def payloads_match?(expected, recorded)
-        return expected.matches?(recorded) if expected.respond_to?(:matches?)
-        return expected.nil? || expected.empty? || expected == recorded
+      def event_names_match?(expected, actual)
+        return expected.matches?(actual) if expected.respond_to?(:matches?)
+        return expected.match?(actual) if expected.respond_to?(:match?)
+        return expected == actual
+      end
+
+      def payloads_match?(expected, actual)
+        return expected.matches?(actual) if expected.respond_to?(:matches?)
+        return expected.nil? || expected.empty? || expected == actual
       end
 
       def add_matched(event, payload)

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = "hello@lithic.tech"
   s.homepage = "https://github.com/lithictech/sidekiq-amigo"
   s.licenses = "MIT"
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
   s.description = <<~DESC
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC

--- a/spec/amigo/amigo_spec.rb
+++ b/spec/amigo/amigo_spec.rb
@@ -157,7 +157,27 @@ RSpec.describe Amigo do
 
       expect do
         Amigo.publish("my-event-5", 123)
+      end.to publish("my-event-5", [123])
+
+      expect do
+        Amigo.publish("my-event-5", 123)
       end.to_not publish("my-event-6")
+
+      expect do
+        Amigo.publish("my-event-5", 123)
+      end.to publish("my-event-5", match([be > 120]))
+
+      expect do
+        Amigo.publish("my-event-5", 123)
+      end.to publish("my-event-5").with_payload(match([be > 120]))
+
+      expect do
+        Amigo.publish("my-event-5", 123)
+      end.to publish(start_with("my-event"))
+
+      expect do
+        Amigo.publish("my-event-5", 123)
+      end.to publish(/my-event-\d/)
     end
   end
 


### PR DESCRIPTION
Previously, `expect { }.to publish('eventname')` could only handle a literal topic like `'eventname'`.

Now, it can be a matcher like `start_with('prefix')`, or a regex, like `/^prefix/`.