### PR TITLE
Up sidekiq dependency to version 7 (#1)

### DIFF
--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC
   s.files = Dir["lib/**/*.rb"]
-  s.add_runtime_dependency("sidekiq", "~> 6")
+  s.add_runtime_dependency("sidekiq", "~> 7")
   s.add_runtime_dependency("sidekiq-cron", "~> 1")
   s.add_development_dependency("platform-api", "> 0")
   s.add_development_dependency("rack", "~> 2.2")


### PR DESCRIPTION
In order to upgrade the sidekiq gem to version 7 (or other than version 6.x), it is necessary to update the gemfile `sidekiq` dependency to version. If you try to upgrade sidekiq, you will get a gemfile dependency conflict since sidekiq-amigo depends on version `~> 6`