### PR TITLE
Add on_unhandled_exception to autoscaler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   redis:
     image: "redis:6"

--- a/lib/amigo/autoscaler/heroku.rb
+++ b/lib/amigo/autoscaler/heroku.rb
@@ -81,7 +81,6 @@ module Amigo
         app_id_or_app_name: ENV.fetch("HEROKU_APP_NAME"),
         formation_id_or_formation_type: "worker"
       )
-
         @heroku = heroku
         @max_additional_workers = max_additional_workers
         @app_id_or_app_name = app_id_or_app_name


### PR DESCRIPTION
Exceptions in the thread would kill the thread
and not give us a chance to alert, because error handling systems like Sentry do not wrap threads without extra work.