### PR TITLE
Disable backoff behavior when near OOM conditions

### DIFF
--- a/lib/amigo/memory_pressure.rb
+++ b/lib/amigo/memory_pressure.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Amigo
+  # Helper class to detect when the Redis server is under memory pressure.
+  # In these cases, we want to disable queue backoff behavior.
+  # There is a significant risk that the backoff behavior will take jobs from the queue,
+  # and immediately try and reschedule them. If that happens in an OOM condition,
+  # the re-push will fail and the job can be lost.
+  #
+  # Additionally, the backoff behavior causes delays that slow down the clearing of the queue.
+  #
+  # In these high-memory-utilization conditions, it makes more sense to disable the backoff logic
+  # and just brute force to try to get through the queue.
+  class MemoryPressure
+    # Percentage at which the server is considered under memory pressure.
+    DEFAULT_THRESHOLD = 90
+
+    # Default seconds a memory check is good for. See +check_ttl+.
+    DEFAULT_CHECK_TTL = 120
+
+    class << self
+      # Return the singleton instance, creating a cached value if needed.
+      def instance
+        return @instance ||= self.new
+      end
+
+      # Set the instance, or use nil to reset.
+      attr_writer :instance
+    end
+
+    # When did we last check for pressure?
+    attr_reader :last_checked_at
+
+    # What was the result of the last check?
+    # true is under pressure, false if not.
+    attr_reader :last_check_result
+
+    # See +DEFAULT_CHECK_TTL+.
+    attr_reader :check_ttl
+
+    # See +DEFAULT_THRESHOLD+.
+    attr_reader :threshold
+
+    def initialize(check_ttl: DEFAULT_CHECK_TTL, threshold: DEFAULT_THRESHOLD)
+      @last_checked_at = nil
+      @check_ttl = check_ttl
+      @threshold = threshold
+      @last_check_result = nil
+    end
+
+    # Return true if the server is under memory pressure.
+    # When this is the case, we want to disable backoff,
+    # since it will delay working through the queue,
+    # and can also result in a higher likelihood of lost jobs,
+    # since returning them back to the queue will fail.
+    def under_pressure?
+      return @last_check_result unless self.needs_check?
+      @last_check_result = self.calculate_under_pressure
+      @last_checked_at = Time.now
+      return @last_check_result
+    end
+
+    private def needs_check?
+      return true if @last_checked_at.nil?
+      return (@last_checked_at + @check_ttl) < Time.now
+    end
+
+    private def calculate_under_pressure
+      meminfo = self.get_memory_info
+      used_bytes = meminfo.fetch("used_memory", "0").to_f
+      max_bytes = meminfo.fetch("maxmemory", "0").to_f
+      return false if used_bytes.zero? || max_bytes.zero?
+      percentage = (used_bytes / max_bytes) * 100
+      return percentage > self.threshold
+    end
+
+    protected def get_memory_info
+      Sidekiq.redis do |c|
+        c.info :memory
+      end
+    end
+  end
+end

--- a/spec/amigo/helpers.rb
+++ b/spec/amigo/helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "amigo/memory_pressure"
+
 module Amigo
   module Test; end
 end
@@ -15,6 +17,21 @@ module Amigo
 
       def call(*args)
         @calls << args
+      end
+    end
+
+    class FakeMemoryPressure < Amigo::MemoryPressure
+      attr_accessor :calls, :response
+
+      def initialize(used_memory:, maxmemory:, **kw)
+        @response = {"used_memory" => used_memory.to_s, "maxmemory" => maxmemory.to_s}
+        @calls = 0
+        super(**kw)
+      end
+
+      def get_memory_info
+        @calls += 1
+        return @response
       end
     end
   end

--- a/spec/amigo/memory_pressure_spec.rb
+++ b/spec/amigo/memory_pressure_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "timecop"
+
+require "amigo/memory_pressure"
+
+require_relative "./helpers"
+
+RSpec.describe Amigo::MemoryPressure, :async, :db do
+  it "returns under pressure if the current memory usage is above the threshold" do
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 50, maxmemory: 51)
+    expect(mp).to be_under_pressure
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 30, maxmemory: 51)
+    expect(mp).to_not be_under_pressure
+  end
+
+  it "caches under pressure checks for its TTL" do
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 50, maxmemory: 51)
+    expect(mp).to be_under_pressure
+    expect(mp).to be_under_pressure
+    expect(mp).to be_under_pressure
+    expect(mp.calls).to eq(1)
+    Timecop.travel(Time.now + 300) do
+      expect(mp).to be_under_pressure
+      expect(mp).to be_under_pressure
+      expect(mp).to be_under_pressure
+      expect(mp.calls).to eq(2)
+    end
+  end
+
+  it "is not under pressure if either memory field is missing or zero" do
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 0, maxmemory: 0)
+    mp.response = {"used_memory" => "0", "maxmemory" => "1024"}
+    expect(mp).to_not be_under_pressure
+
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 0, maxmemory: 0)
+    mp.response = {"used_memory" => "1024", "maxmemory" => "0"}
+    expect(mp).to_not be_under_pressure
+
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 0, maxmemory: 0)
+    mp.response = {"used_memory" => "1024"}
+    expect(mp).to_not be_under_pressure
+
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 0, maxmemory: 0)
+    mp.response = {"maxmemory" => "1024"}
+    expect(mp).to_not be_under_pressure
+
+    mp = Amigo::Test::FakeMemoryPressure.new(used_memory: 0, maxmemory: 0)
+    mp.response = {}
+    expect(mp).to_not be_under_pressure
+  end
+
+  it "sends the correct memory command to Redis" do
+    conncls = Class.new do
+      attr_reader :infos
+
+      def info(arg)
+        @infos ||= []
+        @infos << arg
+        return {}
+      end
+    end
+    conn = conncls.new
+    expect(Sidekiq).to receive(:redis) do |&block|
+      block.call(conn)
+    end
+    mp = Amigo::MemoryPressure.new
+    mp.under_pressure?
+    expect(conn.infos).to eq([:memory])
+  end
+end


### PR DESCRIPTION
When Redis is using a lot of memory (90% of available), we want to disable queue backoff behavior.
There is a significant risk that the backoff
behavior will take jobs from the queue,
and immediately try and reschedule them.
If that happens in an OOM condition,
the re-push will fail and the job can be lost.

Additionally, the backoff behavior causes delays that slow down the clearing of the queue.

In these high-memory-utilization conditions,
it makes more sense to disable the backoff logic
and just brute force to try to get through the queue.