### PR TITLE
Upgrade to Sidekiq 8

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.3', '3.2', '3.1', '3.0']
+        ruby-version: ['3.4', '3.3', '3.2', '3.1']
+        gemfile: ['Gemfile']
     services:
       redis:
         image: redis

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.4', '3.3', '3.2', '3.1']
+        ruby-version: ['3.4', '3.3', '3.2']
         gemfile: ['Gemfile']
     services:
       redis:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,3 +34,8 @@ jobs:
         run: bundle exec rubocop
       - name: Run specs
         run: bundle exec rspec spec/
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: lithictech/sidekiq-amigo

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 3.2
 
 Gemspec/DevelopmentDependencies:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.4
 
 Gemspec/DevelopmentDependencies:
   Enabled: false
@@ -68,7 +68,7 @@ Lint/UselessAssignment:
 # https://rubocop.readthedocs.io/en/latest/cops_naming/
 Naming/AccessorMethodName:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - 'spec/**/*'
 Naming/MethodParameterName:

--- a/lib/amigo.rb
+++ b/lib/amigo.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "redis"
 require "sidekiq"
 require "sidekiq-cron"
 
@@ -61,18 +60,18 @@ require "sidekiq-cron"
 # to control the matching rules more closely than File.fnmatch can provide.
 #
 # Jobs must implement a `_perform` method, which takes a Amigo::Event.
-# Note that normal Sidekiq workers use a 'perform' method that takes a variable number of arguments;
+# Note that normal Sidekiq jobs use a 'perform' method that takes a variable number of arguments;
 # the base Async::Job class has this method and delegates its business logic to the subclass _perform method.
 #
 # Routing
 #
-# There are two special workers that are important for the overall functioning of the system
-# (and do not inherit from Job but rather than Sidekiq::Worker so they are not classified and treated as 'Jobs').
+# There are two special jobs that are important for the overall functioning of the system
+# (and do not inherit from Job but rather than Sidekiq::Job so they are not classified and treated as 'Jobs').
 #
 # The first is the AuditLogger, which is a basic job that logs all async events.
 # This acts as a useful change log for the state of the database.
 #
-# The second special worker is the Router, which calls `perform` on the event Jobs
+# The second special job is the Router, which calls `perform` on the event Jobs
 # that match the routing information, as explained in Jobs.
 # It does this by filtering through all event-based jobs and performing the ones with a route match.
 #

--- a/lib/amigo/audit_logger.rb
+++ b/lib/amigo/audit_logger.rb
@@ -4,7 +4,7 @@ require "amigo"
 
 module Amigo
   class AuditLogger
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     def audit_log_level
       return :info

--- a/lib/amigo/job.rb
+++ b/lib/amigo/job.rb
@@ -7,7 +7,7 @@ require "amigo"
 module Amigo
   module Job
     def self.extended(cls)
-      cls.include(Sidekiq::Worker)
+      cls.include(Sidekiq::Job)
       cls.extend(ClassMethods)
       cls.pattern = ""
       cls.include(InstanceMethods)

--- a/lib/amigo/memory_pressure.rb
+++ b/lib/amigo/memory_pressure.rb
@@ -74,10 +74,23 @@ module Amigo
       return percentage > self.threshold
     end
 
-    protected def get_memory_info
-      Sidekiq.redis do |c|
-        c.info :memory
+    def get_memory_info
+      s = self.get_memory_info_string
+      return self.parse_memory_string(s)
+    end
+
+    protected def get_memory_info_string
+      s = Sidekiq.redis do |c|
+        c.call("INFO", "MEMORY")
       end
+      return s
+    end
+
+    protected def parse_memory_string(s)
+      # See bottom of https://redis.io/docs/latest/commands/info/ for format.
+      pairs = s.split("\r\n").reject { |line| line.start_with?("#") }.map { |pair| pair.split(":", 2) }
+      h = pairs.to_h
+      return h
     end
   end
 end

--- a/lib/amigo/retry.rb
+++ b/lib/amigo/retry.rb
@@ -83,6 +83,8 @@ module Amigo
     end
 
     class ServerMiddleware
+      include Sidekiq::ServerMiddleware
+
       def call(worker, job, _queue)
         yield
       rescue Amigo::Retry::Retry => e

--- a/lib/amigo/retry.rb
+++ b/lib/amigo/retry.rb
@@ -3,7 +3,7 @@
 require "sidekiq"
 require "sidekiq/api"
 
-# Middleware so Sidekiq workers can use a custom retry logic.
+# Middleware so Sidekiq jobs can use a custom retry logic.
 # See +Amigo::Retry::Retry+, +Amigo::Retry::Die+,
 # and +Amigo::Retry::OrDie+ for more details
 # on how these should be used.
@@ -120,14 +120,14 @@ module Amigo
         end
       end
 
-      def amigo_retry_in(worker_class, item, interval)
+      def amigo_retry_in(job_class, item, interval)
         # pulled from perform_in
         int = interval.to_f
         now = Time.now.to_f
         ts = (int < 1_000_000_000 ? now + int : int)
         item["at"] = ts if ts > now
         item["retry_count"] = item.fetch("retry_count", 0) + 1
-        worker_class.client_push(item)
+        job_class.client_push(item)
       end
     end
   end

--- a/lib/amigo/router.rb
+++ b/lib/amigo/router.rb
@@ -6,7 +6,7 @@ require "amigo"
 
 module Amigo
   class Router
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     def perform(event_json)
       event_name = event_json["name"]

--- a/lib/amigo/scheduled_job.rb
+++ b/lib/amigo/scheduled_job.rb
@@ -8,7 +8,7 @@ require "amigo"
 module Amigo
   module ScheduledJob
     def self.extended(cls)
-      cls.include(Sidekiq::Worker)
+      cls.include(Sidekiq::Job)
       cls.sidekiq_options(retry: false)
       cls.extend(ClassMethods)
       cls.splay_duration = 30

--- a/lib/amigo/semaphore_backoff_job.rb
+++ b/lib/amigo/semaphore_backoff_job.rb
@@ -33,7 +33,7 @@ require "amigo/memory_pressure"
 # - `semaphore_expiry` should return the TTL of the semaphore key.
 #   Defaults to 30 seconds. See below for key expiry and negative semaphore value details.
 # - `before_perform` is called before calling the `perform` method.
-#   This is required so that implementers can set worker state, based on job arguments,
+#   This is required so that implementers can set job state, based on job arguments,
 #   that can be used for calculating the semaphore key.
 #
 # Note that we give the semaphore key an expiry. This is to avoid situation where
@@ -41,7 +41,7 @@ require "amigo/memory_pressure"
 # have fewer than the expected number of jobs running.
 #
 # This does mean that, when a job runs longer than the semaphore expiry,
-# another worker can be started, which would increment the counter back to 1.
+# another job can be started, which would increment the counter back to 1.
 # When the original job ends, the counter would be 0; then when the new job ends,
 # the counter would be -1. To avoid negative counters (which create the same issue
 # around missing decrements), if we ever detect a negative 'jobs running',
@@ -78,11 +78,11 @@ module Amigo
 
     module InstanceMethods
       def semaphore_key
-        raise NotImplementedError, "must be implemented on worker"
+        raise NotImplementedError, "must be implemented on job"
       end
 
       def semaphore_size
-        raise NotImplementedError, "must be implemented on worker"
+        raise NotImplementedError, "must be implemented on job"
       end
 
       def semaphore_backoff

--- a/lib/amigo/spec_helpers.rb
+++ b/lib/amigo/spec_helpers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "amigo"
-require "sidekiq/worker"
 
 module Amigo
   module SpecHelpers
@@ -248,7 +247,7 @@ module Amigo
       return PerformAsyncJobMatcher.new(job)
     end
 
-    # Like a Sidekiq worker's perform_inline,
+    # Like a Sidekiq job's perform_inline,
     # but allows an arbitrary item to be used, rather than just the
     # given class and args. For example, when testing,
     # you may need to assume something like 'retry_count' is in the job payload,
@@ -256,11 +255,11 @@ module Amigo
     # This allows those arbitrary job payload fields
     # to be included when the job is run.
     module_function def sidekiq_perform_inline(klass, args, item=nil)
-      Sidekiq::Worker::Setter.override_item = item
+      Sidekiq::Job::Setter.override_item = item
       begin
         klass.perform_inline(*args)
       ensure
-        Sidekiq::Worker::Setter.override_item = nil
+        Sidekiq::Job::Setter.override_item = nil
       end
     end
 
@@ -304,7 +303,7 @@ module Amigo
 end
 
 module ::Sidekiq
-  module Worker
+  module Job
     class Setter
       class << self
         attr_accessor :override_item

--- a/lib/amigo/spec_helpers.rb
+++ b/lib/amigo/spec_helpers.rb
@@ -266,7 +266,7 @@ module Amigo
     module_function def drain_sidekiq_jobs(q)
       all_sidekiq_jobs(q).each do |job|
         klass = job.item.fetch("class")
-        klass = Sidekiq::Testing.constantize(klass) if klass.is_a?(String)
+        klass = Object.const_get(klass) if klass.is_a?(String)
         sidekiq_perform_inline(klass, job.item["args"], job.item)
         job.delete
       end
@@ -281,6 +281,8 @@ module Amigo
     # Use this middleware to pass an arbitrary callback evaluated before a job runs.
     # Make sure to call +reset+ after the test.
     class ServerCallbackMiddleware
+      include Sidekiq::ServerMiddleware
+
       class << self
         attr_accessor :callback
       end

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = "hello@lithic.tech"
   s.homepage = "https://github.com/lithictech/sidekiq-amigo"
   s.licenses = "MIT"
-  s.required_ruby_version = ">= 3.0.0"
+  s.required_ruby_version = ">= 3.4.0"
   s.description = <<~DESC
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC
   s.files = Dir["lib/**/*.rb"]
-  s.add_runtime_dependency("sidekiq", "~> 6")
-  s.add_runtime_dependency("sidekiq-cron", "~> 1")
+  s.add_runtime_dependency("sidekiq", "~> 8")
+  s.add_runtime_dependency("sidekiq-cron", "~> 2")
   s.add_development_dependency("platform-api", "> 0")
-  s.add_development_dependency("rack", "~> 2.2")
+  s.add_development_dependency("rack", "~> 3.1")
   s.add_development_dependency("rspec", "~> 3.10")
   s.add_development_dependency("rspec-core", "~> 3.10")
   s.add_development_dependency("rubocop", "~> 1.48")

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = "hello@lithic.tech"
   s.homepage = "https://github.com/lithictech/sidekiq-amigo"
   s.licenses = "MIT"
-  s.required_ruby_version = ">= 3.4.0"
+  s.required_ruby_version = ">= 3.2.0"
   s.description = <<~DESC
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC

--- a/sidekiq-amigo.gemspec
+++ b/sidekiq-amigo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     sidekiq-amigo provides a pubsub system and other enhancements around Sidekiq.
   DESC
   s.files = Dir["lib/**/*.rb"]
-  s.add_runtime_dependency("sidekiq", "~> 8")
+  s.add_runtime_dependency("sidekiq", ">= 7")
   s.add_runtime_dependency("sidekiq-cron", "~> 2")
   s.add_development_dependency("platform-api", "> 0")
   s.add_development_dependency("rack", "~> 3.1")

--- a/spec/amigo/autoscaler_spec.rb
+++ b/spec/amigo/autoscaler_spec.rb
@@ -330,18 +330,20 @@ RSpec.describe Amigo::Autoscaler do
     end
   end
 
+  def listkeys = Sidekiq.redis { |c| c.call("KEYS", "*") }
+
   it "can delete its persisted fields" do
-    expect(Sidekiq.redis(&:keys)).to be_empty
+    expect(listkeys).to be_empty
     expect(Sidekiq::Queue).to receive(:all).and_return([fake_q("x", 1), fake_q("y", 20)])
     o = instance
     expect(o).to receive(:alert_test).with({"y" => 20}, duration: 0, depth: 1)
     o.setup
     o.check
-    expect(Sidekiq.redis(&:keys)).to contain_exactly(
+    expect(listkeys).to contain_exactly(
       "amigo/autoscaler/depth", "amigo/autoscaler/last_alerted", "amigo/autoscaler/latency_event_started",
     )
     o.unpersist
-    expect(Sidekiq.redis(&:keys)).to be_empty
+    expect(listkeys).to be_empty
   end
 
   describe "Heroku" do
@@ -376,7 +378,7 @@ RSpec.describe Amigo::Autoscaler do
       expect(reqinfo).to have_been_made
       expect(requp).to have_been_made
       expect(reqdown).to have_been_made
-      expect(Sidekiq.redis(&:keys)).to_not include("amigo/autoscaler/heroku/active_event_initial_workers")
+      expect(listkeys).to_not include("amigo/autoscaler/heroku/active_event_initial_workers")
     end
 
     it "does not scale if initial workers are 0" do

--- a/spec/amigo/autoscaler_spec.rb
+++ b/spec/amigo/autoscaler_spec.rb
@@ -203,6 +203,11 @@ RSpec.describe Amigo::Autoscaler do
         expect(o4).to receive(:alert_test).with({"y" => 20}, duration: 0, depth: 1)
         o4.setup
         o4.check
+        expect(o4.fetch_persisted).to have_attributes(
+          last_alerted_at: Time.at(130),
+          depth: 1,
+          latency_event_started_at: Time.at(130),
+        )
       end
     end
 

--- a/spec/amigo/memory_pressure_spec.rb
+++ b/spec/amigo/memory_pressure_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe Amigo::MemoryPressure, :async, :db do
     conncls = Class.new do
       attr_reader :infos
 
-      def info(arg)
+      def call(*args)
         @infos ||= []
-        @infos << arg
-        return {}
+        @infos << args
+        return "# Memory x:y"
       end
     end
     conn = conncls.new
@@ -66,6 +66,11 @@ RSpec.describe Amigo::MemoryPressure, :async, :db do
     end
     mp = Amigo::MemoryPressure.new
     mp.under_pressure?
-    expect(conn.infos).to eq([:memory])
+    expect(conn.infos).to eq([["INFO", "MEMORY"]])
+  end
+
+  it "can parse the memory info output" do
+    m = described_class.new
+    expect(m.get_memory_info).to include("active_defrag_running" => "0", "used_memory_peak_human" => "905.68K")
   end
 end

--- a/spec/amigo/memory_pressure_spec.rb
+++ b/spec/amigo/memory_pressure_spec.rb
@@ -71,6 +71,6 @@ RSpec.describe Amigo::MemoryPressure, :async, :db do
 
   it "can parse the memory info output" do
     m = described_class.new
-    expect(m.get_memory_info).to include("active_defrag_running" => "0", "used_memory_peak_human" => "905.68K")
+    expect(m.get_memory_info).to include("active_defrag_running" => /\d+/, "allocator_allocated" => /\d+/)
   end
 end

--- a/spec/amigo/queue_backoff_job_spec.rb
+++ b/spec/amigo/queue_backoff_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Amigo::QueueBackoffJob do
   end
 
   after(:each) do
-    Sidekiq::Worker.drain_all
+    Sidekiq::Job.drain_all
     described_class.reset
   end
 
@@ -20,7 +20,7 @@ RSpec.describe Amigo::QueueBackoffJob do
 
   def create_job_class(perform:, dependent_queues:, calculate_backoff:)
     cls = Class.new do
-      include Sidekiq::Worker
+      include Sidekiq::Job
       include Amigo::QueueBackoffJob
 
       perform && define_method(:perform) do |*args|
@@ -36,7 +36,7 @@ RSpec.describe Amigo::QueueBackoffJob do
       end
 
       def self.to_s
-        return "BackoffJob::TestWorker"
+        return "BackoffJob::TestJob"
       end
     end
     stub_const(cls.to_s, cls)

--- a/spec/amigo/retry_spec.rb
+++ b/spec/amigo/retry_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Amigo::Retry do
   def create_job_class(perform: nil, ex: nil, &block)
     raise "pass :perform or :ex" unless perform || ex
     cls = Class.new do
-      include Sidekiq::Worker
+      include Sidekiq::Job
 
       define_method(:perform) do |*args|
         raise ex if ex
@@ -25,7 +25,7 @@ RSpec.describe Amigo::Retry do
       end
 
       def self.to_s
-        return "Retry::TestWorker"
+        return "Retry::TestJob"
       end
 
       block && class_eval do

--- a/spec/amigo/retry_spec.rb
+++ b/spec/amigo/retry_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Amigo::Retry do
   before(:each) do
     Sidekiq.redis(&:flushdb)
     Sidekiq::Testing.disable!
-    Sidekiq.server_middleware.add(described_class::ServerMiddleware)
+    Sidekiq.default_configuration.server_middleware.add(described_class::ServerMiddleware)
   end
 
   after(:each) do
-    Sidekiq.server_middleware.remove(described_class::ServerMiddleware)
+    Sidekiq.default_configuration.server_middleware.remove(described_class::ServerMiddleware)
     Sidekiq.redis(&:flushdb)
   end
 

--- a/spec/amigo/semaphore_backoff_job_spec.rb
+++ b/spec/amigo/semaphore_backoff_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Amigo::SemaphoreBackoffJob do
 
   def create_job_class(perform:, key: "semkey", size: 5, &block)
     cls = Class.new do
-      include Sidekiq::Worker
+      include Sidekiq::Job
       include Amigo::SemaphoreBackoffJob
 
       define_method(:perform) { |*args| perform[*args] }
@@ -28,7 +28,7 @@ RSpec.describe Amigo::SemaphoreBackoffJob do
       define_method(:semaphore_size) { size }
 
       def self.to_s
-        return "SemaphoreBackoffJob::TestWorker"
+        return "SemaphoreBackoffJob::TestJob"
       end
 
       block && class_eval do

--- a/spec/amigo/semaphore_backoff_job_spec.rb
+++ b/spec/amigo/semaphore_backoff_job_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Amigo::SemaphoreBackoffJob do
 
   it "only sets key expiry for the first job taking the semaphore" do
     Sidekiq.redis do |c|
-      c.setex("semkey", 100, "1") # Pretend the semaphore is already taken, and we check the TTL later
+      c.set("semkey", "1", "EX", 100) # Pretend the semaphore is already taken, and we check the TTL later
     end
     calls = []
     kls = create_job_class(perform: ->(a) { calls << a })


### PR DESCRIPTION
Depend on sidekiq v8, sidekiq-cron v2, and ruby 3.2+

Decided to just swing big and migrate forward; anyone already on v7 isn't using Amigo, and anyone going to v7 to upgrade may as well go to v8

This should have minimal downstream impacts, beyond the sort of annoying Sidekiq upgrade.

Breaking changes:
- Depend on sidekiq v8
- Depend on sidekiq-cron v2
- Rename Worker->Job
- Remove support for Ruby <= 3.1
